### PR TITLE
Add toaster component to layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import localFont from "next/font/local";
 
 import "./globals.css";
 import PlausibleProvider from "next-plausible";
+import { Toaster } from "@/components/ui/toaster";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -32,6 +33,7 @@ export default function RootLayout({
         className='font-sans antialiased'
       ><PlausibleProvider domain="edit0r.vercel.app">
         {children}
+        <Toaster />
         <footer className="footer p-4
     bg-transparent text-secondary text-xs
     flex items-center justify-between">


### PR DESCRIPTION
## Summary
- include `Toaster` in app layout so toast messages appear

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840acf91928832fac348b95cb22a8f1