### PR TITLE
Fix headline style and wording

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,9 +3,11 @@ import SimpleEditor from '@/components/simple-editor'
 export default function Home() {
   return (
     <main className="flex flex-col min-h-screen bg-gradient-to-br from-slate-400 to-slate-800 dark:from-gray-800 dark:to-gray-900 flex items-center justify-center">
-      <p className="text-xl font-mono font-thin  
-        text-start bg-gradient-to-r text-slate-800 bg-clip-text text-transparent p-4"
-        >No frills, cookie free, tracking free <span className='font-bold'>text editor</span></p>
+      <h1
+        className="text-2xl font-mono font-bold text-center bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent p-4"
+      >
+        Pure text, zero fuss—your cookie-free editor
+      </h1>
       <div className="dark:bg-gray-800 rounded-lg shadow-2xl p-6 w-full m-[10%]">
         
         <SimpleEditor />


### PR DESCRIPTION
## Summary
- improve hero headline wording
- add a bright gradient so the headline text is readable

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840afb95770832f9b60aa67eed68532