### PR TITLE
Fix button alignment and header spacing

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,14 +2,11 @@ import SimpleEditor from '@/components/simple-editor'
 
 export default function Home() {
   return (
-    <main className="flex flex-col min-h-screen bg-gradient-to-br from-slate-400 to-slate-800 dark:from-gray-800 dark:to-gray-900 flex items-center justify-center">
-      <h1
-        className="text-2xl font-mono font-bold text-center bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent p-4"
-      >
+    <main className="flex flex-col min-h-screen bg-gradient-to-br from-slate-400 to-slate-800 dark:from-gray-800 dark:to-gray-900 items-center">
+      <h1 className="mt-6 mb-4 text-4xl font-mono font-bold text-center text-gray-700 dark:text-gray-200">
         Pure text, zero fuss—your cookie-free editor
       </h1>
-      <div className="dark:bg-gray-800 rounded-lg shadow-2xl p-6 w-full m-[10%]">
-        
+      <div className="dark:bg-gray-800 rounded-lg shadow-2xl p-6 w-full mx-4 mb-8">
         <SimpleEditor />
       </div>
     </main>

--- a/components/simple-editor.tsx
+++ b/components/simple-editor.tsx
@@ -2,8 +2,9 @@
 
 import React, { useState, useEffect } from 'react'
 import AceEditor from 'react-ace'
-import { Button } from '@/components/ui/button'
+import { Button, buttonVariants } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { cn } from '@/lib/utils'
 import { toast } from '@/hooks/use-toast'
 import { Copy, Clipboard, FileCode2, Moon, Sun, Minimize2, Maximize2, Save, FolderOpen, Check } from 'lucide-react'
 
@@ -285,27 +286,27 @@ export default function SimpleEditor() {
             <SelectItem value="csv">CSV</SelectItem>
           </SelectContent>
         </Select>
-        <div className="space-x-2">
-          <Button onClick={copyToClipboard} title="Copy to Clipboard">
+        <div className="flex flex-wrap items-center space-x-2">
+          <Button size="icon" onClick={copyToClipboard} title="Copy to Clipboard">
             <Copy className="h-4 w-4" />
           </Button>
-          <Button onClick={pasteFromClipboard} title="Paste from Clipboard">
+          <Button size="icon" onClick={pasteFromClipboard} title="Paste from Clipboard">
             <Clipboard className="h-4 w-4" />
           </Button>
-          <Button onClick={formatContent} title="Format Content">
+          <Button size="icon" onClick={formatContent} title="Format Content">
             <FileCode2 className="h-4 w-4" />
           </Button>
-          <Button onClick={validateContent} title="Validate Content">
+          <Button size="icon" onClick={validateContent} title="Validate Content">
             <Check className="h-4 w-4" />
           </Button>
-          <Button onClick={isFlattened ? unflattenContent : flattenContent} title={isFlattened ? "Unflatten Content" : "Flatten Content"}>
+          <Button size="icon" onClick={isFlattened ? unflattenContent : flattenContent} title={isFlattened ? "Unflatten Content" : "Flatten Content"}>
             {isFlattened ? <Maximize2 className="h-4 w-4" /> : <Minimize2 className="h-4 w-4" />}
           </Button>
-          <Button onClick={saveContent} title="Save Content">
+          <Button size="icon" onClick={saveContent} title="Save Content">
             <Save className="h-4 w-4" />
           </Button>
           <Select onValueChange={loadContent} onOpenChange={(open) => open && loadSavedKeys()}>
-            <SelectTrigger className="w-9 px-0">
+            <SelectTrigger className={cn(buttonVariants({ size: 'icon' }))}>
               <FolderOpen className="h-4 w-4" />
             </SelectTrigger>
             <SelectContent>
@@ -317,7 +318,7 @@ export default function SimpleEditor() {
               ))}
             </SelectContent>
           </Select>
-          <Button onClick={toggleDarkMode} title="Toggle Dark Mode">
+          <Button size="icon" onClick={toggleDarkMode} title="Toggle Dark Mode">
             {isDarkMode ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
           </Button>
         </div>


### PR DESCRIPTION
## Summary
- unify button styles with icon-sized actions
- match the load button styling to other actions
- reduce headline margins and tame the colours

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b4a6fb58832f8f386efe92a68bff