### PR TITLE
feat: add clean Claude output toolbar action

### DIFF
--- a/components/editor/editor-toolbar.tsx
+++ b/components/editor/editor-toolbar.tsx
@@ -14,6 +14,7 @@ import {
   Redo,
   Moon,
   Sun,
+  Terminal,
 } from 'lucide-react'
 
 import { ModeSelect } from './mode-select'
@@ -52,6 +53,7 @@ interface EditorToolbarProps {
   onLineBreakOptionsChange: React.Dispatch<React.SetStateAction<LineBreakOptions>>
   onResetOptions: () => void
   onSmartProcess: () => void
+  onCleanClaudeOutput: () => void
   lastOperation: string | null
   isDarkMode: boolean
   onToggleDarkMode: () => void
@@ -110,6 +112,7 @@ export function EditorToolbar({
   onLineBreakOptionsChange,
   onResetOptions,
   onSmartProcess,
+  onCleanClaudeOutput,
   lastOperation,
   isDarkMode,
   onToggleDarkMode,
@@ -141,6 +144,7 @@ export function EditorToolbar({
         label={isFlattened ? 'Unflatten' : 'Flatten'}
         onClick={onFlattenToggle}
       />
+      <ToolbarButton icon={Terminal} label="Clean Claude Output" onClick={onCleanClaudeOutput} />
       <LineBreakPopover
         lineCount={lineCount}
         lineEndings={lineEndings}

--- a/components/simple-editor.tsx
+++ b/components/simple-editor.tsx
@@ -25,6 +25,7 @@ import {
   processLineBreaks,
   flattenContent,
   unflattenContent,
+  cleanClaudeOutput,
 } from '@/lib/editor-actions'
 
 export default function SimpleEditor() {
@@ -135,6 +136,20 @@ export default function SimpleEditor() {
     }
   }
 
+  const handleCleanClaudeOutput = () => {
+    try {
+      const cleaned = cleanClaudeOutput(content)
+      addToHistory(cleaned, 'Clean Claude Output')
+      toast({ title: 'Claude output cleaned' })
+    } catch (error) {
+      toast({
+        title: 'Cleaning failed',
+        description: error instanceof Error ? error.message : 'Unknown error',
+        variant: 'destructive',
+      })
+    }
+  }
+
   const handleSave = (name: string) => {
     const result = saveContent(name, content)
     if (result.ok) {
@@ -207,6 +222,7 @@ export default function SimpleEditor() {
           onLineBreakOptionsChange={setLineBreakOptions}
           onResetOptions={resetOptions}
           onSmartProcess={handleSmartProcess}
+          onCleanClaudeOutput={handleCleanClaudeOutput}
           lastOperation={lastOperation}
           isDarkMode={isDarkMode}
           onToggleDarkMode={toggleDarkMode}

--- a/lib/editor-actions.ts
+++ b/lib/editor-actions.ts
@@ -1,5 +1,5 @@
 import Papa from 'papaparse'
-import { smartRemoveLineBreaks, enhancedFlattenContent } from '@/lib/utils'
+import { smartRemoveLineBreaks, enhancedFlattenContent, cleanClaudeOutput as cleanClaudeOutputUtil } from '@/lib/utils'
 import type { LineBreakOptions } from '@/lib/utils'
 
 const VOID_ELEMENTS = new Set([
@@ -156,4 +156,8 @@ export function unflattenContent(content: string, mode: string): string {
   }
 
   return unflattened
+}
+
+export function cleanClaudeOutput(content: string): string {
+  return cleanClaudeOutputUtil(content)
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -178,6 +178,56 @@ export function enhancedFlattenContent(content: string, options: Partial<LineBre
   return encodeURIComponent(processed)
 }
 
+// Clean Claude Code terminal output
+// Removes common leading whitespace and collapses multiple empty lines
+export function cleanClaudeOutput(content: string): string {
+  const lines = content.split(/\r?\n/)
+
+  // Count indent frequencies among indented lines to find the common Claude Code indent
+  const indentCounts: Record<number, number> = {}
+  for (const line of lines) {
+    if (line.trim() === '') continue
+    const match = line.match(/^[ \t]+/)
+    if (match) {
+      const len = match[0].length
+      indentCounts[len] = (indentCounts[len] || 0) + 1
+    }
+  }
+
+  // Find the minimum indent that appears on indented lines
+  const indents = Object.keys(indentCounts).map(Number).sort((a, b) => a - b)
+  const minIndent = indents.length > 0 ? indents[0] : 0
+
+  const cleaned: string[] = []
+  let lastWasEmpty = false
+
+  for (const line of lines) {
+    // Strip common indentation (only if line has enough leading whitespace)
+    const match = line.match(/^[ \t]*/)
+    const leadingWs = match ? match[0].length : 0
+    const dedented = leadingWs >= minIndent ? line.slice(minIndent) : line
+    const stripped = dedented.trimEnd()
+    const isEmpty = stripped === ''
+
+    if (isEmpty) {
+      // Collapse consecutive empty lines to single empty line
+      if (!lastWasEmpty) {
+        cleaned.push('')
+        lastWasEmpty = true
+      }
+    } else {
+      cleaned.push(stripped)
+      lastWasEmpty = false
+    }
+  }
+
+  // Trim leading/trailing empty lines
+  while (cleaned.length > 0 && cleaned[0] === '') cleaned.shift()
+  while (cleaned.length > 0 && cleaned[cleaned.length - 1] === '') cleaned.pop()
+
+  return cleaned.join('\n')
+}
+
 // History management for undo/redo
 export class ProcessingHistoryManager {
   private history: ProcessingHistory[] = []


### PR DESCRIPTION
## Summary
- Adds "Clean Claude Output" button to toolbar (Terminal icon)
- Strips common leading whitespace from pasted Claude Code terminal output
- Trims trailing whitespace from each line
- Collapses consecutive empty lines to single empty line
- Preserves relative indentation (e.g., SQL formatting)

## Test plan
- [ ] Paste Claude Code terminal output with leading spaces
- [ ] Verify common indentation is removed
- [ ] Verify trailing whitespace is trimmed
- [ ] Verify relative indentation is preserved
- [ ] Verify undo/redo works

🤖 Generated with [Claude Code](https://claude.com/claude-code)